### PR TITLE
fix: Move box-shadow property to appearance category

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,6 @@ function layout() {
 		'border-image-source',
 		'border-image-width',
 		'border-spacing',
-		'box-shadow',
 
 		// grid
 		'grid',
@@ -279,6 +278,7 @@ function appearance() {
 		'background-position-y',
 		'background-repeat',
 		'background-size',
+		'box-shadow',
 		'mix-blend-mode',
 
 		// image

--- a/test/test.css
+++ b/test/test.css
@@ -131,7 +131,6 @@
   border-image-source: none;
   border-image-width: 1;
   border-spacing: 0;
-  box-shadow: none;
 
   /* grid */
   grid-area: auto;
@@ -349,6 +348,7 @@
   background-position-y: 0;
   background-repeat: repeat;
   background-size: auto;
+  box-shadow: none;
   mix-blend-mode: color;
 
   /* image */


### PR DESCRIPTION
This pull request moves the `box-shadow` property from the `border` category to the `appearance` category, where it logically belongs. This change improves the organization of CSS properties and makes it easier for developers to find the property they need. No other changes are included in this pull request.