### PR TITLE
fix: Fix unintended CSS order

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,6 @@ function layout() {
 		'columns',
 		'column-count',
 		'column-fill',
-		'column-gap',
 		'column-rule',
 		'column-rule-color',
 		'column-rule-style',
@@ -227,7 +226,6 @@ function typography() {
 		'text-emphasis-position',
 		'text-emphasis-style',
 		'text-orientation',
-		'text-overflow',
 
 		// white space & word wrapping
 		'white-space',

--- a/test/test.css
+++ b/test/test.css
@@ -169,6 +169,7 @@
   justify-items: auto;
   justify-self: auto;
   gap: 0;
+  column-gap: normal;
   row-gap: 0;
   vertical-align: auto;
 
@@ -182,7 +183,6 @@
   columns: unset;
   column-count: auto;
   column-fill: balance;
-  column-gap: normal;
   column-rule: medium none currentColor;
   column-rule-color: currentColor;
   column-rule-style: none;
@@ -295,12 +295,12 @@
   text-indent: 0;
   text-justify: 0;
   text-shadow: none;
+  text-overflow: clip;
   text-rendering: auto;
   text-size-adjust: auto;
   text-transform: none;
   text-underline-offset: auto;
   text-underline-position: auto;
-  text-overflow: clip;
 
   /* white space & word wrapping */
   white-space: normal;


### PR DESCRIPTION
FIx a problem that the following CSS properties are placed unintentionally

- `column-gap`
- `text-overflow`
